### PR TITLE
Fix case handling of binary sensor

### DIFF
--- a/ecowitt2mqtt/util/battery.py
+++ b/ecowitt2mqtt/util/battery.py
@@ -1,8 +1,8 @@
 """Define battery utilities."""
 from typing import Union
 
-BATTERY_STATE_OFF = "off"
-BATTERY_STATE_ON = "on"
+BATTERY_STATE_OFF = "OFF"
+BATTERY_STATE_ON = "ON"
 
 
 def calculate_battery(value: Union[float, int]) -> Union[float, str]:


### PR DESCRIPTION
Binary sensors since Home Assistant require states in uppercase to work correctly.

**Describe what the PR does:**

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/<ISSUE ID>
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
